### PR TITLE
Refactor layout into modular helper methods

### DIFF
--- a/app_layout.py
+++ b/app_layout.py
@@ -64,223 +64,240 @@ class LayoutBuilder:
             },
         )
 
+    # -------- ACTUAL section --------
     def _build_actual_section(self):
         return html.Div(
             [
                 html.H3("Závislost příkonu na čase"),
                 html.Div(style={"height": "10px"}),
                 html.Div(self.range_text_act, style={"margin-bottom": "20px"}),
-
-                # --- ACTUAL: Date controls in one row ---
-                html.Div(
-                    [
-                        dcc.Dropdown(
-                            id="time-unit-actual",
-                            options=[
-                                {"label": "Rok", "value": "year"},
-                                {"label": "Měsíc", "value": "month"},
-                                {"label": "Týden", "value": "week"},
-                                {"label": "Den", "value": "day"},
-                            ],
-                            value=self.default_unit_act,
-                            clearable=False,
-                            style={
-                                "width": "150px",
-                                "border-radius": "20px",
-                                "margin-left": ACTUAL_PERIOD_RIGHT,
-                                "margin-top": -ACTUAL_PERIOD_UP,
-                            },
-                        ),
-                        dcc.Dropdown(
-                            id="time-value-actual",
-                            options=self.period_options_act.get(
-                                self.default_unit_act, []
-                            ),
-                            value=self.default_value_act,
-                            style={
-                                "width": "200px",
-                                "margin-left": 10 + ACTUAL_DATEPICKER_RIGHT,
-                                "border-radius": "20px",
-                                "margin-top": -ACTUAL_DATEPICKER_UP,
-                            },
-                        ),
-                    ],
-                    style={
-                        "display": "flex",
-                        "align-items": "center",
-                        "gap": "10px",
-                        "flex-wrap": "nowrap",
-                        "margin-bottom": "10px",
-                    },
-                ),
-
-                # --- ACTUAL: Graph + variables; graph made wider via flex ---
-                html.Div(
-                    [
-                        dcc.Loading(
-                            id="loading-actual",
-                            type="circle",
-                            children=[
-                                dcc.Graph(
-                                    id="consumption_vs_time",
-                                    style={
-                                        "margin-left": ACTUAL_GRAPH_RIGHT,
-                                        "margin-top": -ACTUAL_GRAPH_UP,
-                                        "width": "1000px",
-                                    },
-                                )
-                            ],
-                            style={"flex": "1"}  # let the loading/graph area grow
-                        ),
-                        html.Div(
-                            [
-                                html.Span(
-                                    ""  # "VYBER SI, KTERÁ DATA ZOBRAZÍŠ NA GRAFU (ACTUAL):"
-                                ),
-                                dcc.Checklist(
-                                    id="variable-checklist",
-                                    options=[
-                                        {"label": "IN", "value": "IN"},
-                                        {"label": "OUT", "value": "OUT"},
-                                        {"label": "ATLAS", "value": "ATLAS"},
-                                        {"label": "BUPI", "value": "BUPI"},
-                                        {"label": "RENDER", "value": "RENDER"},
-                                    ],
-                                    value=[],
-                                    style={
-                                        "display": "flex",
-                                        "flex-direction": "column",
-                                        "gap": "10px",
-                                    },
-                                ),
-                            ],
-                            style={
-                                "margin-left": 20 + ACTUAL_VARIABLES_RIGHT,
-                                "display": "flex",
-                                "flex-direction": "column",
-                                "margin-top": -ACTUAL_VARIABLES_UP,
-                                "flex": "0 0 260px",  # fixed sidebar width so graph can expand
-                            },
-                        ),
-                    ],
-                    style={"display": "flex", "align-items": "stretch"},
-                ),
+                self._build_actual_period_controls(),
+                self._build_actual_graph_section(),
                 html.Div(id="actual-data-info", style={"margin-top": "30px"}),
             ],
             style={"display": "flex", "flex-direction": "column"},
         )
 
-    # --- TOTAL section (kept, but force the two controls to stay inline) ---
+    def _build_actual_period_controls(self):
+        """Dropdowns for selecting period in the ACTUAL section."""
+        return html.Div(
+            [
+                dcc.Dropdown(
+                    id="time-unit-actual",
+                    options=[
+                        {"label": "Rok", "value": "year"},
+                        {"label": "Měsíc", "value": "month"},
+                        {"label": "Týden", "value": "week"},
+                        {"label": "Den", "value": "day"},
+                    ],
+                    value=self.default_unit_act,
+                    clearable=False,
+                    style={
+                        "width": "150px",
+                        "border-radius": "20px",
+                        "margin-left": ACTUAL_PERIOD_RIGHT,
+                        "margin-top": -ACTUAL_PERIOD_UP,
+                    },
+                ),
+                dcc.Dropdown(
+                    id="time-value-actual",
+                    options=self.period_options_act.get(self.default_unit_act, []),
+                    value=self.default_value_act,
+                    style={
+                        "width": "200px",
+                        "margin-left": 10 + ACTUAL_DATEPICKER_RIGHT,
+                        "border-radius": "20px",
+                        "margin-top": -ACTUAL_DATEPICKER_UP,
+                    },
+                ),
+            ],
+            style={
+                "display": "flex",
+                "align-items": "center",
+                "gap": "10px",
+                "flex-wrap": "nowrap",
+                "margin-bottom": "10px",
+            },
+        )
+
+    def _build_actual_graph_section(self):
+        """Graph with variable checklist for the ACTUAL section."""
+        return html.Div(
+            [
+                dcc.Loading(
+                    id="loading-actual",
+                    type="circle",
+                    children=[
+                        dcc.Graph(
+                            id="consumption_vs_time",
+                            style={
+                                "margin-left": ACTUAL_GRAPH_RIGHT,
+                                "margin-top": -ACTUAL_GRAPH_UP,
+                                "width": "1000px",
+                            },
+                        )
+                    ],
+                    style={"flex": "1"},
+                ),
+                html.Div(
+                    [
+                        html.Span(
+                            ""  # "VYBER SI, KTERÁ DATA ZOBRAZÍŠ NA GRAFU (ACTUAL):",
+                        ),
+                        dcc.Checklist(
+                            id="variable-checklist",
+                            options=[
+                                {"label": "IN", "value": "IN"},
+                                {"label": "OUT", "value": "OUT"},
+                                {"label": "ATLAS", "value": "ATLAS"},
+                                {"label": "BUPI", "value": "BUPI"},
+                                {"label": "RENDER", "value": "RENDER"},
+                            ],
+                            value=[],
+                            style={
+                                "display": "flex",
+                                "flex-direction": "column",
+                                "gap": "10px",
+                            },
+                        ),
+                    ],
+                    style={
+                        "margin-left": 20 + ACTUAL_VARIABLES_RIGHT,
+                        "display": "flex",
+                        "flex-direction": "column",
+                        "margin-top": -ACTUAL_VARIABLES_UP,
+                        "flex": "0 0 260px",
+                    },
+                ),
+            ],
+            style={"display": "flex", "align-items": "stretch"},
+        )
+
+    # -------- TOTAL section --------
     def _build_total_section(self):
         return html.Div(
             [
                 html.H3("Celková spotřeba podle času"),
-                html.Div(
-                    [
-                        dcc.Dropdown(
-                            id="time-unit-total",
-                            options=[
-                                {"label": "Rok", "value": "year"},
-                                {"label": "Měsíc", "value": "month"},
-                                {"label": "Týden", "value": "week"},
-                                {"label": "Den", "value": "day"},
-                            ],
-                            value=self.default_unit_tot,
-                            clearable=False,
-                            style={
-                                "width": "150px",
-                                "border-radius": "20px",
-                                "margin-left": TOTAL_PERIOD_RIGHT,
-                                "margin-top": -TOTAL_PERIOD_UP,
-                            },
-                        ),
-                        dcc.Dropdown(
-                            id="time-value-total",
-                            options=self.period_options_tot.get(
-                                self.default_unit_tot, []
-                            ),
-                            value=self.default_value_tot,
-                            style={
-                                "width": "200px",
-                                "margin-left": 10 + TOTAL_DATEPICKER_RIGHT,
-                                "border-radius": "20px",
-                                "margin-top": -TOTAL_DATEPICKER_UP,
-                            },
-                        ),
-                    ],
-                    style={
-                        "display": "flex",
-                        "align-items": "center",
-                        "gap": "10px",
-                        "flex-wrap": "nowrap",
-                        "margin-bottom": "20px",
-                    },
-                ),
+                self._build_total_period_controls(),
                 html.Div(self.range_text_tot, style={"margin-bottom": "20px"}),
-                html.Div(
-                    [
-                        html.Span(
-                            "VYBER SI FORMÁT ZOBRAZENÍ (TOTAL)",
-                            style={"margin-bottom": "10px", "margin-top": "10px"},
-                        ),
-                        dcc.Dropdown(
-                            id="aggregation-dropdown",
-                            options=[
-                                {"label": "Dny", "value": "D"},
-                                {"label": "Týdny", "value": "T"},
-                                {"label": "Měsíce", "value": "M"},
-                                {"label": "Roky", "value": "R"},
-                                {"label": "Total", "value": "To"},
-                            ],
-                            value="T",
-                            style={
-                                "margin-right": "5px",
-                                "border-radius": "20px",
-                            },
-                        ),
+                self._build_total_aggregation_controls(),
+                self._build_total_bar_mode_controls(),
+                html.Div(id="total-data-info", style={"margin-bottom": "20px"}),
+                self._build_total_graph(),
+            ]
+        )
+
+    def _build_total_period_controls(self):
+        """Dropdowns for selecting period in the TOTAL section."""
+        return html.Div(
+            [
+                dcc.Dropdown(
+                    id="time-unit-total",
+                    options=[
+                        {"label": "Rok", "value": "year"},
+                        {"label": "Měsíc", "value": "month"},
+                        {"label": "Týden", "value": "week"},
+                        {"label": "Den", "value": "day"},
                     ],
+                    value=self.default_unit_tot,
+                    clearable=False,
                     style={
-                        "display": "flex",
-                        "flex-direction": "column",
-                        "margin-bottom": "20px",
+                        "width": "150px",
+                        "border-radius": "20px",
+                        "margin-left": TOTAL_PERIOD_RIGHT,
+                        "margin-top": -TOTAL_PERIOD_UP,
                     },
                 ),
-                html.Div(
-                    [
-                        html.Span(
-                            "FORMÁT SLOUPCŮ",
-                            style={
-                                "font-weight": "bold",
-                                "margin-right": "10px",
-                                "align-self": "center",
-                            },
-                        ),
-                        dcc.RadioItems(
-                            id="bar-mode",
-                            options=[
-                                {"label": "Stacked", "value": "stack"},
-                                {"label": "Grouped", "value": "group"},
-                            ],
-                            value="stack",
-                            inline=True,
-                            style={"margin-bottom": "20px", "margin-top": "20px"},
-                        ),
-                    ],
-                    style={"display": "flex", "align-items": "center"},
+                dcc.Dropdown(
+                    id="time-value-total",
+                    options=self.period_options_tot.get(self.default_unit_tot, []),
+                    value=self.default_value_tot,
+                    style={
+                        "width": "200px",
+                        "margin-left": 10 + TOTAL_DATEPICKER_RIGHT,
+                        "border-radius": "20px",
+                        "margin-top": -TOTAL_DATEPICKER_UP,
+                    },
                 ),
-                html.Div(id="total-data-info", style={"margin-bottom": "20px"}),
-                dcc.Loading(
-                    id="loading-total",
-                    type="circle",
-                    children=[
-                        dcc.Graph(
-                            id="consumption_vs_time_total",
-                            style={
-                                "margin-left": TOTAL_GRAPH_RIGHT,
-                                "margin-top": -TOTAL_GRAPH_UP,
-                            },
-                        )
-                    ],
+            ],
+            style={
+                "display": "flex",
+                "align-items": "center",
+                "gap": "10px",
+                "flex-wrap": "nowrap",
+                "margin-bottom": "20px",
+            },
+        )
+
+    def _build_total_aggregation_controls(self):
+        """Dropdown for aggregation selection in the TOTAL section."""
+        return html.Div(
+            [
+                html.Span(
+                    "VYBER SI FORMÁT ZOBRAZENÍ (TOTAL)",
+                    style={"margin-bottom": "10px", "margin-top": "10px"},
                 ),
-            ]
+                dcc.Dropdown(
+                    id="aggregation-dropdown",
+                    options=[
+                        {"label": "Dny", "value": "D"},
+                        {"label": "Týdny", "value": "T"},
+                        {"label": "Měsíce", "value": "M"},
+                        {"label": "Roky", "value": "R"},
+                        {"label": "Total", "value": "To"},
+                    ],
+                    value="T",
+                    style={
+                        "margin-right": "5px",
+                        "border-radius": "20px",
+                    },
+                ),
+            ],
+            style={
+                "display": "flex",
+                "flex-direction": "column",
+                "margin-bottom": "20px",
+            },
+        )
+
+    def _build_total_bar_mode_controls(self):
+        """Radio buttons for bar mode selection in the TOTAL section."""
+        return html.Div(
+            [
+                html.Span(
+                    "FORMÁT SLOUPCŮ",
+                    style={
+                        "font-weight": "bold",
+                        "margin-right": "10px",
+                        "align-self": "center",
+                    },
+                ),
+                dcc.RadioItems(
+                    id="bar-mode",
+                    options=[
+                        {"label": "Stacked", "value": "stack"},
+                        {"label": "Grouped", "value": "group"},
+                    ],
+                    value="stack",
+                    inline=True,
+                    style={"margin-bottom": "20px", "margin-top": "20px"},
+                ),
+            ],
+            style={"display": "flex", "align-items": "center"},
+        )
+
+    def _build_total_graph(self):
+        """Graph wrapped in a loading indicator for the TOTAL section."""
+        return dcc.Loading(
+            id="loading-total",
+            type="circle",
+            children=[
+                dcc.Graph(
+                    id="consumption_vs_time_total",
+                    style={
+                        "margin-left": TOTAL_GRAPH_RIGHT,
+                        "margin-top": -TOTAL_GRAPH_UP,
+                    },
+                )
+            ],
         )


### PR DESCRIPTION
## Summary
- Split `LayoutBuilder` into smaller helper methods for ACTUAL and TOTAL sections to simplify HTML structure.
- Added dedicated builders for period controls, graph sections, aggregation and bar-mode selectors.

## Testing
- `python -m py_compile app_layout.py`
- `python - <<'PY'
from app_layout import LayoutBuilder
period_options={'day':[{'label':'2024-01-01','value':'2024-01-01'}]}
layout=LayoutBuilder(period_options,period_options,'day','2024-01-01','day','2024-01-01','','').build_layout()
print('components',len(layout.children))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6899de9b944c8331b30c0661d255d41b